### PR TITLE
Fix: index unstyled on iOS 16 Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
     <title>&lt;vellum-doc> Demo</title>
+
     <script type="module" src="./vellum-doc.js"></script>
     <style>
       vellum-doc {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vellum-doc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vellum-doc",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sindresorhus/slugify": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum-doc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple web component",
   "main": "vellum-doc.js",
   "module": "vellum-doc.js",

--- a/src/vellum-doc.ts
+++ b/src/vellum-doc.ts
@@ -23,35 +23,31 @@ export class VellumDocument extends LitElement {
       --font-family: var(--index-font-family, san-serif);
 
       font-size: var(--index-font-size, 15px);
+    }
 
-      h1 {
-        font: var(--index-level-1-font, bold 1.3em var(--font-family));
-        line-height: 1em;
-        text-align: center;
-      }
+    #index h1 {
+      font: var(--index-level-1-font, bold 1.3em var(--font-family));
+      line-height: 1em;
+      text-align: center;
+    }
 
-      h2 {
-        font: var(--index-level-2-font, bold 1.15em var(--font-family));
-      }
+    #index h2 {
+      font: var(--index-level-2-font, bold 1.15em var(--font-family));
+    }
 
-      h3 {
-        font: var(--index-level-3-font, 1em var(--font-family));
-        padding-left: 1.4em;
-      }
+    #index h3 {
+      font: var(--index-level-3-font, 1em var(--font-family));
+      padding-left: 1.4em;
+    }
 
-      h4 {
-        padding-left: 3em;
-        font: var(--index-level-4-font, 0.9em var(--font-family));
-      }
+    #index h4 {
+      padding-left: 3em;
+      font: var(--index-level-4-font, 0.9em var(--font-family));
+    }
 
-      a {
-        color: inherit;
-        text-decoration: inherit;
-      }
-
-      @media (max-width: 700px) {
-        display: none;
-      }
+    #index a {
+      color: inherit;
+      text-decoration: inherit;
     }
 
     .scrollable {
@@ -65,9 +61,15 @@ export class VellumDocument extends LitElement {
       margin-left: calc(
         var(--index-width, var(--default-index-width)) + var(--gap) / 2
       );
+    }
 
-      @media (max-width: 700px) {
+    @media (width < 700px) {
+      #document {
         margin-left: 0;
+      }
+
+      #index {
+        display: none;
       }
     }
   `
@@ -96,6 +98,7 @@ export class VellumDocument extends LitElement {
   }
 
   override render() {
+    console.log('test')
     return html`
       <div id="index" class="scrollable">${this.renderIndex()}</div>
       <article id="document">


### PR DESCRIPTION
The document index is unstyled in Safari for iOS 16 devices, due to lack of support for nested CSS. Simply using un-nested CSS fixes these display issues.

Fixes:

https://github.com/grislyeye/vellum-doc/issues/10

Potentially fixes similar issues with the Samsung Internet browser:

https://github.com/grislyeye/vellum-doc/issues/9